### PR TITLE
Updates for PR on OpenMS v2.4.0

### DIFF
--- a/easybuild/easyconfigs/c/Cbc/Cbc-2.10.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Cbc/Cbc-2.10.3-foss-2018b.eb
@@ -40,17 +40,16 @@ configopts += '--with-mumps-lib="-lcmumps -ldmumps -lsmumps -lzmumps -lmumps_com
 # Disable GLPK, dependencies have to be built with it as well
 configopts += '--without-glpk '
 # Use CoinUtils from EB
-configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-lib="-lCoinUtils" '
 configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
 # Use Clp from EB
-configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" --with-clp-incdir="$EBROOTCLP/include/coin" '
+configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" '
 configopts += '--with-clp-datadir=$EBROOTCLP/share/coin/Data '
 # Use Osi from EB (also needs links to Clp due to OsiClpSolver)
 configopts += '--with-osi-lib="-lOsiClp -lClpSolver -lClp -lOsi" '
-configopts += '--with-osi-incdir="$EBROOTOSI/include/coin -I$EBROOTCLP/include/coin" '
 configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
 # Use Cgl from EB
-configopts += '--with-cgl-lib="-lCgl" --with-cgl-incdir="$EBROOTCGL/include/coin" '
+configopts += '--with-cgl-lib="-lCgl" '
 configopts += '--with-cgl-datadir=$EBROOTCGL/share/coin/Data '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/Cgl/Cgl-0.60.2-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Cgl/Cgl-0.60.2-foss-2018b.eb
@@ -30,14 +30,13 @@ dependencies = [
 ]
 
 # Use CoinUtils from EB
-configopts = '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts = '--with-coinutils-lib="-lCoinUtils" '
 configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
 # Use Clp from EB
-configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" --with-clp-incdir="$EBROOTCLP/include/coin" '
+configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" '
 configopts += '--with-clp-datadir=$EBROOTCLP/share/coin/Data '
 # Use Osi from EB (also needs links to Clp due to OsiClpSolver)
 configopts += '--with-osi-lib="-lOsiClp -lClpSolver -lClp -lOsi" '
-configopts += '--with-osi-incdir="$EBROOTOSI/include/coin -I$EBROOTCLP/include/coin" '
 configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/Clp/Clp-1.17.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/Clp/Clp-1.17.3-foss-2018b.eb
@@ -38,10 +38,10 @@ configopts += '--with-mumps-lib="-lcmumps -ldmumps -lsmumps -lzmumps -lmumps_com
 # Disable GLPK because Clp requires headers from its sources
 configopts += '--without-glpk '
 # Use CoinUtils from EB
-configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-lib="-lCoinUtils" '
 configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
 # Use Osi from EB
-configopts += '--with-osi-lib="-lOsi" --with-osi-incdir=$EBROOTOSI/include/coin '
+configopts += '--with-osi-lib="-lOsi" '
 configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/c/CoinUtils/CoinUtils-2.11.3-GCCcore-7.3.0.eb
@@ -32,4 +32,7 @@ sanity_check_paths = {
     'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
+# other coin-or projects expect <header.hpp> instead of <coin/header.hpp>
+modextrapaths = {'CPATH': 'include/coin'}
+
 moduleclass = "math"

--- a/easybuild/easyconfigs/o/OpenMS/OpenMS-2.4.0-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/OpenMS/OpenMS-2.4.0-foss-2018b.eb
@@ -1,4 +1,4 @@
-easyblock = 'Bundle'
+easyblock = 'CMakeMake'
 
 name = 'OpenMS'
 version = '2.4.0'
@@ -10,27 +10,22 @@ description = """As part of the deNBI Center for integrative Bioinformatics, Ope
 
 toolchain = {'name': 'foss', 'version': '2018b'}
 
-local_configopts = "-DCMAKE_PREFIX_PATH=%(builddir)s/seqan-library-1.4.2 -DCMAKE_CXX_STANDARD_LIBRARIES='-ldl' "
-
-components = [
-    ('SeqAn', '1.4.2-library', {
-        'easyblock': 'Tarball',
-        'source_urls': ['https://github.com/seqan/seqan/releases/download/seqan-v1.4.2/'],
-        'sources': ['seqan-library-1.4.2.tar.bz2'],
-        'checksums': ['77fb437c6f17d41ec41ce0a3bcc3533f91a3482ca63a3a55400e14cb73e64317'],
-    }),
-    (name, version, {
-        'easyblock': 'CMakeMake',
-        'source_urls': ['https://github.com/OpenMS/OpenMS/releases/download/Release%(version)s/'],
-        'sources': ['%(name)s-%(version)s-src.tar.gz'],
-        'checksums': ['86e8176b0f89cc86a10f5c3e60c34140d591e9e6c85f129ccbfa13ecb16a9af2'],
-        'srcdir': '%(builddir)s/OpenMS-%(version)s',
-        'configopts': local_configopts,
-    }),
+source_urls = [
+    'https://github.com/OpenMS/OpenMS/releases/download/Release%(version)s/',
+    'https://github.com/seqan/seqan/releases/download/seqan-v1.4.2/',
+]
+sources = [
+    '%(name)s-%(version)s-src.tar.gz',
+    'seqan-library-1.4.2.tar.bz2',
+]
+checksums = [
+    '86e8176b0f89cc86a10f5c3e60c34140d591e9e6c85f129ccbfa13ecb16a9af2',  # OpenMS-2.4.0-src.tar.gz
+    '77fb437c6f17d41ec41ce0a3bcc3533f91a3482ca63a3a55400e14cb73e64317',  # seqan-library-1.4.2.tar.bz2
 ]
 
 builddependencies = [
     ('CMake', '3.12.1'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [
@@ -53,9 +48,19 @@ dependencies = [
     ('X11', '20180604'),
 ]
 
+configopts = "-DCMAKE_PREFIX_PATH=%(builddir)s/seqan-library-1.4.2 -DCMAKE_CXX_STANDARD_LIBRARIES='-ldl' "
+# Disable reporting to remote servers
+configopts += "-DENABLE_UPDATE_CHECK=OFF "
+# Documentation requires an active X server display and tutorials require LaTex
+configopts += "-DENABLE_DOCS=OFF -DENABLE_TUTORIALS=OFF "
+
 sanity_check_paths = {
     'files': ['lib/libOpenMS.%s' % SHLIB_EXT, 'lib/libOpenMS_GUI.%s' % SHLIB_EXT],
     'dirs': ['bin', 'include/OpenMS', 'lib', 'share/OpenMS'],
 }
+sanity_check_commands = ['OpenMSInfo']
+
+# Disable notifications on new updates
+modextravars = {'OPENMS_DISABLE_UPDATE_CHECK': 1}
 
 moduleclass = "bio"

--- a/easybuild/easyconfigs/o/Osi/Osi-0.108.5-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/o/Osi/Osi-0.108.5-GCCcore-7.3.0.eb
@@ -44,4 +44,7 @@ sanity_check_paths = {
     'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
+# other coin-or projects expect <header.hpp> instead of <coin/header.hpp>
+modextrapaths = {'CPATH': 'include/coin'}
+
 moduleclass = "math"

--- a/easybuild/easyconfigs/o/Osi/Osi-0.108.5-foss-2018b.eb
+++ b/easybuild/easyconfigs/o/Osi/Osi-0.108.5-foss-2018b.eb
@@ -37,7 +37,7 @@ configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
 # Disable GLPK because Osi requires GLPK<=4.48
 configopts += '--without-glpk '
 # Use CoinUtils from EB
-configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-lib="-lCoinUtils" '
 configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/s/SYMPHONY/SYMPHONY-5.6.16-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SYMPHONY/SYMPHONY-5.6.16-foss-2018b.eb
@@ -49,4 +49,7 @@ sanity_check_paths = {
     'dirs': ['include/coin', 'lib/pkgconfig', 'share/coin']
 }
 
+# other coin-or projects expect <header.hpp> instead of <coin/header.hpp>
+modextrapaths = {'CPATH': 'include/coin'}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SYMPHONY/SYMPHONY-5.6.16-foss-2018b.eb
+++ b/easybuild/easyconfigs/s/SYMPHONY/SYMPHONY-5.6.16-foss-2018b.eb
@@ -31,17 +31,16 @@ configopts = '--with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
 # Disable GLPK, dependencies have to be built with it as well
 configopts += '--without-glpk '
 # Use CoinUtils from EB
-configopts += '--with-coinutils-lib="-lCoinUtils" --with-coinutils-incdir=$EBROOTCOINUTILS/include/coin '
+configopts += '--with-coinutils-lib="-lCoinUtils" '
 configopts += '--with-coinutils-datadir=$EBROOTCOINUTILS/share/coin/Data'
 # Use Clp from EB
-configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" --with-clp-incdir="$EBROOTCLP/include/coin" '
+configopts += '--with-clp-lib="-lOsiClp -lClpSolver -lClp" '
 configopts += '--with-clp-datadir=$EBROOTCLP/share/coin/Data '
 # Use Osi from EB (also needs links to Clp due to OsiClpSolver)
 configopts += '--with-osi-lib="-lOsiClp -lClpSolver -lClp -lOsi" '
-configopts += '--with-osi-incdir="$EBROOTOSI/include/coin -I$EBROOTCLP/include/coin" '
 configopts += '--with-osi-datadir=$EBROOTOSI/share/coin/Data '
 # Use Cgl from EB
-configopts += '--with-cgl-lib="-lCgl" --with-cgl-incdir="$EBROOTCGL/include/coin" '
+configopts += '--with-cgl-lib="-lCgl" '
 configopts += '--with-cgl-datadir=$EBROOTCGL/share/coin/Data '
 
 sanity_check_paths = {


### PR DESCRIPTION
I got OpenMS built and installed on my side. The issue with `LIBSVM` was due to a very old installation on our system and was easily fixed. I hit other issues though. This PR contains the following changes
* Convert the easyconfig to `CMakeMake`: the only thing needed from `seqan` are the header files at build time. Therefore, there is no need to install them in the system. We can just download the sources into `builddir`, use them and be gone.
* Disable building the documentation of OpenMS as it needs an active X screen
* Disable building the tutorials as those need LaTeX
* Make the submission of stats to remote servers and update checks and opt-in feature (disabled by default)
* Adding the extra `CPATHS` to coin-or packages is a good idea. This PR updates those packages removing the explicit include paths in `configopts` as well.